### PR TITLE
Some bank/bankSize fixes for the XK-68 Jog+Shuttle

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,8 @@ const PRODUCTS = {
 		jogByte: 	18,
 		hasShuttle: 1,
 		shuttleByte:19,
-		bankSize: 	68,
+		bankSize: 	80,
+		banks: 2,
 		disableKeys: [29,30,31, 37,38,39, 45,46,47, 53,54,55]
 	},
 };


### PR DESCRIPTION
Due to the "missing" keys the `bankSize` was actually too small and caused issues with the buttons not lighting up the correct backlights. I also needed to add a `banks` key and set it to 2 so that `setBacklightIntensity` would also adjust the red backlights.