### PR TITLE
Add XK-60 to list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If you have one of the untested devices below, please test it and tell us how it
 These devices have been tested to work:
 
 * XK-24
+* XK-60
 * XK-80
 * XK-68 Jog + Shuttle
 * XK-12 Jog
@@ -169,7 +170,6 @@ These devices have been tested to work:
 
 Support for these devices is implemented, but not tested:
 
-* XK-60: Not tested
 * XK-4: Not tested
 * XK-8: Not tested
 * XK-16: Not tested


### PR DESCRIPTION
XK-60 works perfectly fine with the current version, I've been using it in my application and have not run into any issues with keys or LEDs.

Makes sense too since it's quite literally just an XK-80 with a few keys not populated. It even enumerates as XK-80:

```Listening to device (1):
manufacturer   P. I. Engineering
product        XK-80 HID
vendorId       1523
productId      1121
interface      0

1 'data' <Buffer 01 00 01 00 00 00 00 00 00 00 00 00 00 00 b2 75 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
1 'data' <Buffer 01 00 00 00 00 00 00 00 00 00 00 00 00 00 b2 bd 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>

1 'data' <Buffer 01 00 00 01 00 00 00 00 00 00 00 00 00 00 b4 ab 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
1 'data' <Buffer 01 00 00 00 00 00 00 00 00 00 00 00 00 00 b4 f9 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>

1 'data' <Buffer 01 00 00 00 01 00 00 00 00 00 00 00 00 00 b6 ef 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
1 'data' <Buffer 01 00 00 00 00 00 00 00 00 00 00 00 00 00 b7 3f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>

1 'data' <Buffer 01 00 00 00 00 01 00 00 00 00 00 00 00 00 b9 2e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
1 'data' <Buffer 01 00 00 00 00 00 00 00 00 00 00 00 00 00 b9 8b 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
```

So I think it can simply be added to the list of supported devices.