### PR TITLE
Add support for XKE-124 T-bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ if (connectedXKeys.length) {
 * 'jog': Triggered when the jog wheel is moved. Emitted with (jogValue)
 * 'shuttle': Triggered when the shuttle is moved. Emitted with (shuttleValue)
 * 'joystick': Triggered when the joystick is moved. Emitted with ({x, y, z})
+* 'tbar': Triggered when the T-bar is moved. Emitted with (tbarPosition, rawPosition)
 
 * 'error': Triggered on error. Emitted with (error).
 
@@ -165,6 +166,7 @@ These devices have been tested to work:
 * XK-80
 * XK-68 Jog + Shuttle
 * XK-12 Jog
+* XKE-124 T-bar
 
 ### Not tested devices (yet)
 
@@ -175,7 +177,7 @@ Support for these devices is implemented, but not tested:
 * XK-16: Not tested
 * XK-12 Joystick: Not tested
 * XR-32: Not tested
-* XKE-28: Not tested
+* XKE-128: Not tested
 
 If you have access to any of the untested devices listed above, it would be very nice if you could provide some data to add to the tests!
 Just do

--- a/examples/xkeys.js
+++ b/examples/xkeys.js
@@ -30,3 +30,7 @@ myXkeysPanel.on('shuttle', shuttlePos => {
 myXkeysPanel.on('joystick', position => {
 	console.log('Joystick has changed:' + position) // {x, y, z}
 })
+// Listen to t-bar changes:
+myXkeysPanel.on('tbar', (position, rawPosition) => {
+    console.log('T-bar position has changed: ' + position + ' (uncalibrated: ' + rawPosition + ')')
+})

--- a/examples/xkeys.ts
+++ b/examples/xkeys.ts
@@ -16,7 +16,6 @@ myXkeysPanel.on('up', keyIndex => {
 
 	// Turn off button light when released:
 	myXkeysPanel.setBacklight(keyIndex, false)
-	myXkeysPanel.setBacklight(keyIndex, false)
 })
 
 // Listen to jog wheel changes:
@@ -30,4 +29,8 @@ myXkeysPanel.on('shuttle', shuttlePos => {
 // Listen to joystick changes:
 myXkeysPanel.on('joystick', position => {
 	console.log('Joystick has changed:' + position) // {x, y, z}
+})
+// Listen to t-bar changes:
+myXkeysPanel.on('tbar', (position, rawPosition) => {
+    console.log('T-bar position has changed: ' + position + ' (uncalibrated: ' + rawPosition + ')')
 })

--- a/src/products.ts
+++ b/src/products.ts
@@ -17,6 +17,9 @@ export interface ProductBase {
 	jogByte?: number
 	hasShuttle?: true
 	shuttleByte?: number
+	hasTbar?: true
+	tbarByte?: number
+	tbarByteRaw?: number
 }
 export interface ProductJog extends ProductBase {
 	hasJog: true
@@ -26,7 +29,12 @@ export interface ProductShuttle extends ProductBase {
 	hasShuttle: true
 	shuttleByte: number
 }
-export type Product = ProductBase | ProductJog | ProductShuttle
+export interface ProductTbar extends ProductBase {
+	hasTbar: true
+	tbarByte: number
+	tbarByteRaw: number
+}
+export type Product = ProductBase | ProductJog | ProductShuttle | ProductTbar
 
 export const PRODUCTS: {[name: string]: Product} = {
 	XK24: {
@@ -113,6 +121,19 @@ export const PRODUCTS: {[name: string]: Product} = {
 		hasPS: 		true,
 		banks: 		2,
 		bankSize: 	80
+	},
+	XKE124TBAR: {
+		identifier: 'XKE-124 T-bar',
+		productId: [1275,1276,1277,1278],
+		columns:	16,
+		rows:		8,
+		hasPS:		false,
+		hasTbar:	true,
+		tbarByte:	30,
+		tbarByteRaw: 31,
+		banks:		2,
+		bankSize:	128,
+		disableKeys: [108,109,110,111]
 	},
 	XKE128: {	// This has not been tested
 		identifier: 'XKE-128',


### PR DESCRIPTION
Adds support for the [XKE-124 T-bar](https://xkeys.com/xk124.html) with a new `tbar` event.

I tested all the functions on my XKE-124 and it works as expected. I also smoke tested with my XK-60 to make sure everything still works on devices without a T-bar.

For the record, I also fixed a typo in `README.md` and removed a duplicate line in `examples/xkeys.ts`.