### PR TITLE
Reconnect event

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
           npm whoami
-      - name: Publish nightly to NPM
+      - name: Publish to NPM
         if: ${{ steps.check-npm-token.outputs.is-ok }}
         run: yarn lerna:publish from-package --no-verify-access --yes
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+
+### Bug Fixes
+
+* re-add devicePath ([349f6a9](https://github.com/SuperFlyTV/xkeys/commit/349f6a93ace9480e18d5ed695186920165fea6e7))
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+
+### Features
+
+* add feature: "Automatic UnitId mode" ([f7c3a86](https://github.com/SuperFlyTV/xkeys/commit/f7c3a869e8820f856831aad576ce7978dfb9d75c))
+* add XKeys.uniqueId property, to be used with automaticUnitIdMode ([a2e6d7a](https://github.com/SuperFlyTV/xkeys/commit/a2e6d7a6ec917d82bc2a71c1922c22c061232908))
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package xkeys-monorepo

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     ],
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.2.0-alpha.0"
+    "version": "2.2.0-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     ],
     "npmClient": "yarn",
     "useWorkspaces": true,
-    "version": "2.1.1"
+    "version": "2.2.0-alpha.0"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+
+### Bug Fixes
+
+* re-add devicePath ([349f6a9](https://github.com/SuperFlyTV/xkeys/commit/349f6a93ace9480e18d5ed695186920165fea6e7))
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+
+### Features
+
+* add feature: "Automatic UnitId mode" ([f7c3a86](https://github.com/SuperFlyTV/xkeys/commit/f7c3a869e8820f856831aad576ce7978dfb9d75c))
+* add XKeys.uniqueId property, to be used with automaticUnitIdMode ([a2e6d7a](https://github.com/SuperFlyTV/xkeys/commit/a2e6d7a6ec917d82bc2a71c1922c22c061232908))
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package @xkeys-lib/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/core",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "NPM package to interact with the X-keys panels",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/core",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "description": "NPM package to interact with the X-keys panels",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -62,6 +62,7 @@ export interface XKeysEvents {
 	tbar: (index: number, value: number, eventMetadata: EventMetadata) => void
 
 	disconnected: () => void
+	reconnected: () => void
 	error: (err: any) => void
 }
 export interface XKeysInfo {

--- a/packages/core/src/xkeys.ts
+++ b/packages/core/src/xkeys.ts
@@ -549,6 +549,10 @@ export class XKeys extends EventEmitter {
 	public _getDeviceInfo(): DeviceInfo {
 		return this.deviceInfo
 	}
+	/** The unique id of the xkeys-panel. Note: This is only available if options.automaticUnitIdMode is set for the Watcher */
+	public get uniqueId(): string {
+		return `${this.info.productId}_${this.unitId}`
+	}
 	/**
 	 * Writes a Buffer to the X-keys device
 	 *

--- a/packages/core/src/xkeys.ts
+++ b/packages/core/src/xkeys.ts
@@ -44,10 +44,7 @@ export class XKeys extends EventEmitter {
 		return XKEYS_VENDOR_ID
 	}
 
-	constructor(
-		private device: HIDDevice,
-		private deviceInfo: DeviceInfo
-	) {
+	constructor(private device: HIDDevice, private deviceInfo: DeviceInfo, private _devicePath: string | undefined) {
 		super()
 
 		this.product = this._setupDevice(deviceInfo)
@@ -546,6 +543,9 @@ export class XKeys extends EventEmitter {
 	}
 	public _getDeviceInfo(): DeviceInfo {
 		return this.deviceInfo
+	}
+	public get devicePath(): string | undefined {
+		return this._devicePath
 	}
 	/** The unique id of the xkeys-panel. Note: This is only available if options.automaticUnitIdMode is set for the Watcher */
 	public get uniqueId(): string {

--- a/packages/node-record-test/CHANGELOG.md
+++ b/packages/node-record-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+**Note:** Version bump only for package @xkeys-lib/record-test
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 **Note:** Version bump only for package @xkeys-lib/record-test

--- a/packages/node-record-test/CHANGELOG.md
+++ b/packages/node-record-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+**Note:** Version bump only for package @xkeys-lib/record-test
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package @xkeys-lib/record-test

--- a/packages/node-record-test/package.json
+++ b/packages/node-record-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/record-test",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "private": true,
   "description": "A script for recording tests",
   "main": "dist/index.js",
@@ -41,10 +41,10 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@xkeys-lib/core": "^2.2.0-alpha.0",
+    "@xkeys-lib/core": "^2.2.0-alpha.1",
     "readline": "^1.3.0",
     "tslib": "^2.1.0",
-    "xkeys": "^2.2.0-alpha.0"
+    "xkeys": "^2.2.0-alpha.1"
   },
   "optionalDependencies": {
     "find": "^0.3.0",

--- a/packages/node-record-test/package.json
+++ b/packages/node-record-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/record-test",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "private": true,
   "description": "A script for recording tests",
   "main": "dist/index.js",
@@ -41,10 +41,10 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@xkeys-lib/core": "^2.1.1",
+    "@xkeys-lib/core": "^2.2.0-alpha.0",
     "readline": "^1.3.0",
     "tslib": "^2.1.0",
-    "xkeys": "^2.1.1"
+    "xkeys": "^2.2.0-alpha.0"
   },
   "optionalDependencies": {
     "find": "^0.3.0",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+
+### Bug Fixes
+
+* re-add devicePath ([349f6a9](https://github.com/SuperFlyTV/xkeys/commit/349f6a93ace9480e18d5ed695186920165fea6e7))
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+
+### Features
+
+* add feature: "Automatic UnitId mode" ([f7c3a86](https://github.com/SuperFlyTV/xkeys/commit/f7c3a869e8820f856831aad576ce7978dfb9d75c))
+* add XKeys.uniqueId property, to be used with automaticUnitIdMode ([a2e6d7a](https://github.com/SuperFlyTV/xkeys/commit/a2e6d7a6ec917d82bc2a71c1922c22c061232908))
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package xkeys

--- a/packages/node/examples/multiplePanels.js
+++ b/packages/node/examples/multiplePanels.js
@@ -1,0 +1,67 @@
+const { XKeysWatcher } = require('../dist')
+
+/*
+	This example shows how multiple devices should be handled, using automaticUnitIdMode.
+*/
+
+const memory = {}
+
+
+// Set up the watcher for xkeys:
+const watcher = new XKeysWatcher({
+	automaticUnitIdMode: true
+})
+
+watcher.on('connected', (xkeysPanel) => {
+	console.log(`A new X-keys panel of type ${xkeysPanel.info.name} connected`)
+
+	const newName = 'HAL ' + (Object.keys(memory).length + 1)
+
+	// Store the name in a persistent store:
+	memory[xkeysPanel.uniqueId] = {
+		name: newName
+	}
+	console.log(`I'm going to call this panel "${newName}", it has productId=${xkeysPanel.info.productId}, unitId=${xkeysPanel.info.unitId}`)
+
+
+	xkeysPanel.on('disconnected', () => {
+		console.log(`X-keys panel ${memory[xkeysPanel.uniqueId].name} was disconnected`)
+	})
+	xkeysPanel.on('error', (...errs) => {
+		console.log('X-keys error:', ...errs)
+	})
+
+	xkeysPanel.on('reconnected', () => {
+		console.log(`Hello again, ${memory[xkeysPanel.uniqueId].name}!`)
+	})
+
+	// Listen to pressed buttons:
+	xkeysPanel.on('down', (keyIndex, metadata) => {
+		console.log(`Button ${keyIndex} pressed`)
+	})
+	// Listen to released buttons:
+	// xkeysPanel.on('up', (keyIndex, metadata) => {
+	// 	console.log('Button released', keyIndex, metadata)
+	// })
+
+	// // Listen to jog wheel changes:
+	// xkeysPanel.on('jog', (index, deltaPos, metadata) => {
+	// 	console.log(`Jog ${index} position has changed`, deltaPos, metadata)
+	// })
+	// // Listen to shuttle changes:
+	// xkeysPanel.on('shuttle', (index, shuttlePos, metadata) => {
+	// 	console.log(`Shuttle ${index} position has changed`, shuttlePos, metadata)
+	// })
+	// // Listen to joystick changes:
+
+	// xkeysPanel.on('joystick', (index, position, metadata) => {
+	// 	console.log(`Joystick ${index} position has changed`, position, metadata) // {x, y, z}
+	// })
+	// // Listen to t-bar changes:
+	// xkeysPanel.on('tbar', (index, position, metadata) => {
+	// 	console.log(`T-bar ${index} position has changed`, position, metadata)
+	// })
+})
+
+// To stop watching, call
+// watcher.stop().catch(console.error)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "An npm module for interfacing with the X-keys panels in Node.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@types/node-hid": "^1.3.0",
-    "@xkeys-lib/core": "^2.2.0-alpha.0",
+    "@xkeys-lib/core": "^2.2.0-alpha.1",
     "node-hid": "^2.1.1",
     "tslib": "^2.1.0"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "description": "An npm module for interfacing with the X-keys panels in Node.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@types/node-hid": "^1.3.0",
-    "@xkeys-lib/core": "^2.1.1",
+    "@xkeys-lib/core": "^2.2.0-alpha.0",
     "node-hid": "^2.1.1",
     "tslib": "^2.1.0"
   },

--- a/packages/node/src/methods.ts
+++ b/packages/node/src/methods.ts
@@ -87,7 +87,7 @@ export async function setupXkeysPanel(devicePathOrHIDDevice?: HID.Device | HID.H
 
 	const deviceWrap = new NodeHIDDevice(device)
 
-	const xkeys = new XKeys(deviceWrap, deviceInfo)
+	const xkeys = new XKeys(deviceWrap, deviceInfo, devicePath)
 
 	// Wait for the device to initialize:
 	await xkeys.init()

--- a/packages/node/src/watcher.ts
+++ b/packages/node/src/watcher.ts
@@ -67,8 +67,11 @@ export class XKeysWatcher extends EventEmitter {
 	public debug = false
 	/** A list of the devices we've called setupXkeysPanels for */
 	private setupXkeysPanels: XKeys[] = []
+	private prevConnectedIdentifiers: { [key: string]: XKeys } = {}
+	/** Unique unitIds grouped into productId groups. */
+	private uniqueIds = new Map<number, number>()
 
-	constructor() {
+	constructor(private options?: XKeysWatcherOptions) {
 		super()
 
 		watcherCount++
@@ -206,8 +209,33 @@ export class XKeysWatcher extends EventEmitter {
 					// Store for future reference:
 					this.seenDevicePaths[devicePath].xkeys = xkeysPanel
 
-					// Emit to the consumer:
-					this.emit('connected', xkeysPanel)
+					if (this.options?.automaticUnitIdMode) {
+						if (xkeysPanel.unitId === 0) {
+							// if it is 0, we assume that it's new from the factory and can be safely changed
+							xkeysPanel.setUnitId(this._getNextUniqueId(xkeysPanel)) // the lookup-cache is stored either in memory, or preferrably on disk
+						}
+						// the PID+UID pair is enough to uniquely identify a panel.
+						const uniqueIdentifier = `${xkeysPanel.info.productId}_${xkeysPanel.unitId}`
+						const previousXKeysPanel = this.prevConnectedIdentifiers[uniqueIdentifier]
+						if (previousXKeysPanel) {
+							// This panel has been connected before.
+
+							// We want the XKeys-instance to emit a 'reconnected' event.
+							// This means that we kill off the newly created xkeysPanel, and
+
+							previousXKeysPanel._handleDeviceReconnected(
+								xkeysPanel._getHIDDevice(),
+								xkeysPanel._getDeviceInfo()
+							)
+						} else {
+							// It seems that this panel hasn't been connected before
+							this.emit('connected', xkeysPanel)
+							this.prevConnectedIdentifiers[uniqueIdentifier] = xkeysPanel
+						}
+					} else {
+						// Default behaviour:
+						this.emit('connected', xkeysPanel)
+					}
 				} else {
 					this.handleRemovedDevice(xkeysPanel)
 				}
@@ -216,10 +244,31 @@ export class XKeysWatcher extends EventEmitter {
 				this.emit('error', err)
 			})
 	}
+	private _getNextUniqueId(xkeysPanel: XKeys): number {
+		let nextId = this.uniqueIds.get(xkeysPanel.info.productId)
+		if (!nextId) {
+			nextId = 32 // Starting at 32
+		} else {
+			nextId++
+		}
+		if (nextId > 255) throw new Error('No more unique ids available!')
+
+		this.uniqueIds.set(xkeysPanel.info.productId, nextId)
+
+		return nextId
+	}
 	private handleRemovedDevice(xkeysPanel: XKeys) {
-		xkeysPanel.handleDeviceDisconnected()
+		xkeysPanel._handleDeviceDisconnected()
 	}
 	private debugLog(...args: any[]) {
 		if (this.debug) console.log(...args)
 	}
+}
+export interface XKeysWatcherOptions {
+	/**
+	 * This activates the "Automatic UnitId mode", which enables several features:
+	 * First, any x-keys panel with unitId===0 will be issued a (pseudo unique) unitId upon connection, in order for it to be uniquely identified.
+	 * This allows for the connection-events to work a bit differently, mainly enabling the "reconnected"-event for when a panel has been disconnected, then reconnected again.
+	 */
+	automaticUnitIdMode: true
 }

--- a/packages/node/src/watcher.ts
+++ b/packages/node/src/watcher.ts
@@ -193,7 +193,7 @@ export class XKeysWatcher extends EventEmitter {
 		this.debugLog('handleNewDevice', devicePath)
 
 		setupXkeysPanel(devicePath)
-			.then((xkeysPanel) => {
+			.then((xkeysPanel: XKeys) => {
 				this.setupXkeysPanels.push(xkeysPanel)
 				// Since this is async, check if the panel is still connected
 				if (this.seenDevicePaths[devicePath]) {
@@ -215,7 +215,7 @@ export class XKeysWatcher extends EventEmitter {
 							xkeysPanel.setUnitId(this._getNextUniqueId(xkeysPanel)) // the lookup-cache is stored either in memory, or preferrably on disk
 						}
 						// the PID+UID pair is enough to uniquely identify a panel.
-						const uniqueIdentifier = `${xkeysPanel.info.productId}_${xkeysPanel.unitId}`
+						const uniqueIdentifier: string = xkeysPanel.uniqueId
 						const previousXKeysPanel = this.prevConnectedIdentifiers[uniqueIdentifier]
 						if (previousXKeysPanel) {
 							// This panel has been connected before.

--- a/packages/webhid-demo/CHANGELOG.md
+++ b/packages/webhid-demo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+**Note:** Version bump only for package @xkeys-lib/webhid-demo
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package @xkeys-lib/webhid-demo

--- a/packages/webhid-demo/CHANGELOG.md
+++ b/packages/webhid-demo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+**Note:** Version bump only for package @xkeys-lib/webhid-demo
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 **Note:** Version bump only for package @xkeys-lib/webhid-demo

--- a/packages/webhid-demo/package.json
+++ b/packages/webhid-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/webhid-demo",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "private": true,
   "license": "MIT",
   "homepage": "https://github.com/SuperFlyTV/xkeys#readme",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "xkeys-webhid": "^2.1.1"
+    "xkeys-webhid": "^2.2.0-alpha.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^7.0.0",

--- a/packages/webhid-demo/package.json
+++ b/packages/webhid-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xkeys-lib/webhid-demo",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "private": true,
   "license": "MIT",
   "homepage": "https://github.com/SuperFlyTV/xkeys#readme",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "xkeys-webhid": "^2.2.0-alpha.0"
+    "xkeys-webhid": "^2.2.0-alpha.1"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^7.0.0",

--- a/packages/webhid/CHANGELOG.md
+++ b/packages/webhid/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.1](https://github.com/SuperFlyTV/xkeys/compare/v2.2.0-alpha.0...v2.2.0-alpha.1) (2021-09-06)
+
+
+### Bug Fixes
+
+* re-add devicePath ([349f6a9](https://github.com/SuperFlyTV/xkeys/commit/349f6a93ace9480e18d5ed695186920165fea6e7))
+
+
+
+
+
 # [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
 
 **Note:** Version bump only for package xkeys-webhid

--- a/packages/webhid/CHANGELOG.md
+++ b/packages/webhid/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0-alpha.0](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1...v2.2.0-alpha.0) (2021-09-06)
+
+**Note:** Version bump only for package xkeys-webhid
+
+
+
+
+
 ## [2.1.1](https://github.com/SuperFlyTV/xkeys/compare/v2.1.1-alpha.1...v2.1.1) (2021-05-24)
 
 **Note:** Version bump only for package xkeys-webhid

--- a/packages/webhid/package.json
+++ b/packages/webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys-webhid",
-  "version": "2.1.1",
+  "version": "2.2.0-alpha.0",
   "description": "An npm module for interfacing with the X-keys panels in a browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@types/w3c-web-hid": "^1.0.0",
-    "@xkeys-lib/core": "^2.1.1",
+    "@xkeys-lib/core": "^2.2.0-alpha.0",
     "buffer": "^6.0.3",
     "detect-browser": "^5.2.0",
     "p-queue": "^6.6.2"

--- a/packages/webhid/package.json
+++ b/packages/webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys-webhid",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "An npm module for interfacing with the X-keys panels in a browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@types/w3c-web-hid": "^1.0.0",
-    "@xkeys-lib/core": "^2.2.0-alpha.0",
+    "@xkeys-lib/core": "^2.2.0-alpha.1",
     "buffer": "^6.0.3",
     "detect-browser": "^5.2.0",
     "p-queue": "^6.6.2"

--- a/packages/webhid/src/methods.ts
+++ b/packages/webhid/src/methods.ts
@@ -32,11 +32,15 @@ export async function setupXkeysPanel(browserDevice: HIDDevice): Promise<XKeys> 
 
 	const deviceWrap = new WebHIDDevice(browserDevice)
 
-	const xkeys = new XKeys(deviceWrap, {
-		product: browserDevice.productName,
-		productId: productId,
-		interface: null, // todo: Check what to use here (collection.usage?)
-	})
+	const xkeys = new XKeys(
+		deviceWrap,
+		{
+			product: browserDevice.productName,
+			productId: productId,
+			interface: null, // todo: Check what to use here (collection.usage?)
+		},
+		undefined
+	)
 
 	// Wait for the device to initialize:
 	await xkeys.init()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,9 +3648,9 @@ dns-equal@^1.0.0:
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
 dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10967,9 +10967,9 @@ write-pkg@^3.1.0:
     write-json-file "^2.2.0"
 
 ws@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
This PR adds the functionality "automaticUnitIdMode", described in [this comment](https://github.com/SuperFlyTV/xkeys/issues/27#issuecomment-814710035).

It adds the optional option `automaticUnitIdMode` to pass into the Watcher, which automatically sets the `unitId` to something, if it's not set in the xkeys-panel, in order to be able tu uniquely identify it.
This allows for using the "reconnected" event, since we're now able to uniquely identify the panel.


Usage example:
```
const watcher = new XKeysWatcher({
	automaticUnitIdMode: true
})

watcher.on('connected', (xkeysPanel) => {
	console.log(`A new X-keys panel connected`)

	xkeysPanel.on('disconnected', () => {
		console.log(`X-keys panel  disconnected`)
	})
	xkeysPanel.on('error', (...errs) => {
		console.log('X-keys error:', ...errs)
	})

	xkeysPanel.on('reconnected', () => {
		console.log(`Panel reconnected!`)
	})
})
```

Also, the `devicePath` property has been re-added (note that it's undefined in web-hid version)

This PR can be tested with `npm install xkeys@2.2.0-alpha.1`