### PR TITLE
feat: Add usePolling option to the XKeysWatcher

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           remove-version-tag-prefix: false
       - name: Bump version to nightly
-        if: ${{ steps.do-publish.outputs.publish }}
+        if: ${{ steps.check-npm-token.outputs.is-ok }}
         run: |
           COMMIT_TIMESTAMP=$(git log -1 --pretty=format:%ct HEAD)
           COMMIT_DATE=$(date -d @$COMMIT_TIMESTAMP +%Y%m%d-%H%M%S)

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -45,7 +45,7 @@ jobs:
           COMMIT_TIMESTAMP=$(git log -1 --pretty=format:%ct HEAD)
           COMMIT_DATE=$(date -d @$COMMIT_TIMESTAMP +%Y%m%d-%H%M%S)
           GIT_HASH=$(git rev-parse --short HEAD)
-          PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')
+          PRERELEASE_TAG=0.0.0-nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')
           yarn lerna:version $PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH --force-publish=* --no-changelog --no-push --no-git-tag-version --yes
         env:
           CI: true

--- a/packages/node/examples/multiple-panels.js
+++ b/packages/node/examples/multiple-panels.js
@@ -18,6 +18,10 @@ const memory = {}
 // Set up the watcher for xkeys:
 const watcher = new XKeysWatcher({
 	automaticUnitIdMode: true,
+
+	// If running on a system (such as some linux flavors) where the 'usb-detection' library doesn't work, enable usePolling instead:
+	// usePolling: true,
+	// pollingInterval: 1000,
 })
 
 watcher.on('connected', (xkeysPanel) => {


### PR DESCRIPTION
This PR adds a new option to the `XKeysWatcher`, to allow watching without using the  "usb-detection" library, since that might not work on all OS:es.


Example of usage:

```
const watcher = new XKeysWatcher({
 usePolling: true,
 pollingInterval: 1000, // optional, default is 1000 ms
})
watcher.on('connected', (xkeysPanel) => {
  console.log('panel connected!')
})
```


