### PR TITLE
Add missing "save" bit

### DIFF
--- a/packages/core/src/xkeys.ts
+++ b/packages/core/src/xkeys.ts
@@ -451,7 +451,7 @@ export class XKeys extends EventEmitter {
 	 */
 	public saveBackLights(): void {
 		this.ensureInitialized()
-		this._write([0, 199])
+		this._write([0, 199, 1])
 	}
 	/**
 	 * Sets the flash frequency of LEDs for the entire X-keys. Flashing will always be synchronized


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

From P.I.Engineering SDK (and confirmed by local testing):

<p><strong>13. Save Backlight State to EEPROM</strong></p>
    <p>Send this output report to change the default backlighting on startup of 
      device to the current backlight state, ie, what ever backlights are on or 
      off at the time this report is sent will be the new default.</p>
    

Byte 1* | Byte 2 | Byte 3 | Bytes 4-36
-- | -- | -- | --
Constant | Command | Save | Constant
0 | 199 | Save | 0


    <p><b>Save:</b> Any value other than 0 will save the current backlight state 
      to the EEPROM so when the device is replugged it will display this save 
      backlighting. Note because there is a limited number of times the EEProm 
      can be written to, it is not a good idea to do this often.</p>