### PR TITLE
Include vendorId in device info

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -69,6 +69,8 @@ export interface XKeysInfo {
 	/** Name of the device */
 	name: string
 
+	/** Vendor id of the HID device */
+	vendorId: number
 	/** Product id of the HID device */
 	productId: number
 	/** Interface number of the HID device */

--- a/packages/core/src/xkeys.ts
+++ b/packages/core/src/xkeys.ts
@@ -287,6 +287,7 @@ export class XKeys extends EventEmitter {
 		return literal<XKeysInfo>({
 			name: this.product.name,
 
+			vendorId: XKEYS_VENDOR_ID,
 			productId: this.product.productId,
 			interface: this.product.interface,
 


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

With our xkeys-server project now supporting other manufacturers, it would be helpful for a device's info to include the manufacturer vendorId. I'm not sure if this is the best way to do the but it works for me.