### PR TITLE
feat: replace usb-detection with usb

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you're upgrading from `<2.0.0`, please read the [_Migrations_](#Migrations) s
 
 This is the recommended way to use this library, to automatically be connected or reconnected to the panel.
 
-_Note: The watcher depends on the [node-usb-detection](https://github.com/MadLittleMods/node-usb-detection) library, which might be unsupported on some platforms._
+_Note: The watcher depends on the [node-usb](https://github.com/node-usb/node-usb) library, which might be unsupported on some platforms._
 
 ```javascript
 const { XKeysWatcher } = require('xkeys')
@@ -199,6 +199,7 @@ watcher.on('connected', (xkeysPanel) => {
 ```
 
 #### automaticUnitIdMode
+
 When this is set to `true`, the XKeysWatcher will enable the `"reconnected"` event for the xkeysPanels.
 
 By default, there is no unique identifier stored on the X-keys panel that can be used to differ between
@@ -208,7 +209,7 @@ if none has been set previously.
 
 #### usePolling
 
-When this is set, the XKeysWatcher will not use the `usb-detection` library for detecting connected panels,
+When this is set, the XKeysWatcher will not use the `usb` library for detecting connected panels,
 but instead resort to polling at an interval (`pollingInterval`).
 This is compatible with more systems and OS:es, but might result in slower detection of new panels.
 
@@ -221,16 +222,16 @@ xkeysPanel.on('down', (keyIndex, metadata) => {
 })
 ```
 
-| Event | Description |
-| -- | --- |
-| `"error"`        | Triggered on error. Emitted with `(error)`. |
-| `"down"`, `"up"` | Triggered when a button is pressed/released. Emitted with `(keyIndex, metadata)`. |
-| `"jog"`          | Triggered when the jog wheel is moved. Emitted with `(index, jogValue, metadata)` |
-| `"shuttle"`      | Triggered when the shuttle is moved. Emitted with `(index, shuttleValue, metadata)` |
-| `"joystick"`     | Triggered when the joystick is moved. Emitted with `(index, {x, y, z, deltaZ})` |
-| `"tbar"`         | Triggered when the T-bar is moved. Emitted with `(index, tbarPosition, metadata)` |
-| `"disconnected"` | Triggered when panel is disconnected. |
-| `"reconnected"`  | Triggered when panel is reconnection. Only emitted when [automaticUnitIdMode](#automaticUnitIdMode) is enabled.  |
+| Event            | Description                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `"error"`        | Triggered on error. Emitted with `(error)`.                                                                     |
+| `"down"`, `"up"` | Triggered when a button is pressed/released. Emitted with `(keyIndex, metadata)`.                               |
+| `"jog"`          | Triggered when the jog wheel is moved. Emitted with `(index, jogValue, metadata)`                               |
+| `"shuttle"`      | Triggered when the shuttle is moved. Emitted with `(index, shuttleValue, metadata)`                             |
+| `"joystick"`     | Triggered when the joystick is moved. Emitted with `(index, {x, y, z, deltaZ})`                                 |
+| `"tbar"`         | Triggered when the T-bar is moved. Emitted with `(index, tbarPosition, metadata)`                               |
+| `"disconnected"` | Triggered when panel is disconnected.                                                                           |
+| `"reconnected"`  | Triggered when panel is reconnection. Only emitted when [automaticUnitIdMode](#automaticUnitIdMode) is enabled. |
 
 ### xkeysPanel Methods
 
@@ -335,25 +336,26 @@ Version `2.0.0` is a breaking changes, which requires several changes in how to 
 
 The most notable changes are:
 
-| Before, `<2.0.0`                                     | Changes in `>=2.0.0` |
-| -- | -- |
-| `let myXkeys = new XKeys()`                          | `let myXkeys = await XKeys.setupXkeysPanel()` |
+| Before, `<2.0.0`                                     | Changes in `>=2.0.0`                                                                                                                                                          |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `let myXkeys = new XKeys()`                          | `let myXkeys = await XKeys.setupXkeysPanel()`                                                                                                                                 |
 | `myXkeys.on('down', (keyIndex) => {} )`              | The numbering of `keyIndexes` has changed:<br/>_ The PS-button is on index 0.<br/>_ Other buttons start on index 1.<br/>\* Numbering of buttons have changed for some models. |
-| `myXkeys.on('downKey', (keyIndex) => {} )`           | Use `.on('down')` instead |
-| `myXkeys.on('upKey', (keyIndex) => {} )`             | Use `.on('up')` instead   |
-| `myXkeys.on('downAlt', (keyIndex) => {} )`           | Use `.on('down')` instead (PS-button is on index 0) |
-| `myXkeys.on('upAlt', (keyIndex) => {} )`             | Use `.on('up')` instead (PS-button is on index 0)   |
-| `myXkeys.on('jog', (position) => {} )`               | `myXkeys.on('jog', (index, position) => {} )`  |
-| `myXkeys.on('shuttle', (position) => {} )`           | `myXkeys.on('shuttle', (index, position) => {} )` |
-| `myXkeys.on('tbar', (position, rawPosition) => {} )` | `myXkeys.on('tbar', (index, position) => {} )` |
-| `myXkeys.on('joystick', (position) => {} )`          | `myXkeys.on('joystick', (index, position) => {} )` |
-| `myXkeys.setBacklight(...)`                          | Arguments have changed, see docs  |
-| `myXkeys.setAllBacklights(...)`                      | Arguments have changed, see docs  |
-| `myXkeys.setLED(index, ...)`                         | `myXkeys.setIndicatorLED(index, ...)` (index 1 = the red, 2 = the green one)  |
+| `myXkeys.on('downKey', (keyIndex) => {} )`           | Use `.on('down')` instead                                                                                                                                                     |
+| `myXkeys.on('upKey', (keyIndex) => {} )`             | Use `.on('up')` instead                                                                                                                                                       |
+| `myXkeys.on('downAlt', (keyIndex) => {} )`           | Use `.on('down')` instead (PS-button is on index 0)                                                                                                                           |
+| `myXkeys.on('upAlt', (keyIndex) => {} )`             | Use `.on('up')` instead (PS-button is on index 0)                                                                                                                             |
+| `myXkeys.on('jog', (position) => {} )`               | `myXkeys.on('jog', (index, position) => {} )`                                                                                                                                 |
+| `myXkeys.on('shuttle', (position) => {} )`           | `myXkeys.on('shuttle', (index, position) => {} )`                                                                                                                             |
+| `myXkeys.on('tbar', (position, rawPosition) => {} )` | `myXkeys.on('tbar', (index, position) => {} )`                                                                                                                                |
+| `myXkeys.on('joystick', (position) => {} )`          | `myXkeys.on('joystick', (index, position) => {} )`                                                                                                                            |
+| `myXkeys.setBacklight(...)`                          | Arguments have changed, see docs                                                                                                                                              |
+| `myXkeys.setAllBacklights(...)`                      | Arguments have changed, see docs                                                                                                                                              |
+| `myXkeys.setLED(index, ...)`                         | `myXkeys.setIndicatorLED(index, ...)` (index 1 = the red, 2 = the green one)                                                                                                  |
 
 ### 2.1.1
 
 Version `2.1.1` has a minor change for when stopping the XKeysWatcher instance:
+
 ```javascript
 const watcher = new XKeysWatcher()
 await watcher.stop() // Now returns a promise
@@ -379,7 +381,7 @@ To install Yarn, just run `npm install -g yarn`.
 
 If you'd like to run and test your local changes, `yarn link` is a useful tool to symlink your local `xkeys` dependency into your test repo.
 
-``` bash
+```bash
 # To set up the xkeys-repo for linking:
 cd your/xkeys/repo
 yarn lerna exec yarn link # This runs "yarn link" in all of the mono-repo packages
@@ -421,25 +423,28 @@ yarn build # To ensure that there are no syntax or build errors
 yarn lint # To ensure that the formatting follows the right rules
 yarn test # To ensure that your code passes the unit tests.
 ```
-If you're adding a new functionality, adding unit tests for it is much appreciated.
 
+If you're adding a new functionality, adding unit tests for it is much appreciated.
 
 ### Notes to maintainers
 
 #### Making a nightly build
-* Push your changes to any branch
-* Trigger a run of [CI: publish-nightly](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-nightly.yml)
+
+- Push your changes to any branch
+- Trigger a run of [CI: publish-nightly](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-nightly.yml)
 
 #### Making a Pre-release
-* Update the branch (preferrably the master branch)
-* `yarn release:bump-prerelease` and push the changes (including the tag)
-* Trigger a run of [CI: publish-prerelease](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-prerelease.yml)
+
+- Update the branch (preferrably the master branch)
+- `yarn release:bump-prerelease` and push the changes (including the tag)
+- Trigger a run of [CI: publish-prerelease](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-prerelease.yml)
 
 #### Making a Release
-* Update the the master branch
-* `yarn release:bump-release` and push the changes (including the tag)
-* Trigger a run of [CI: publish-release](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-release.yml) to publish to NPM.
-* Trigger a run of [CI: publish-demo](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-demo.yml) to update the docs.
+
+- Update the the master branch
+- `yarn release:bump-release` and push the changes (including the tag)
+- Trigger a run of [CI: publish-release](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-release.yml) to publish to NPM.
+- Trigger a run of [CI: publish-demo](https://github.com/SuperFlyTV/xkeys/actions/workflows/publish-demo.yml) to update the docs.
 
 ### License
 

--- a/packages/node/examples/multiple-panels.js
+++ b/packages/node/examples/multiple-panels.js
@@ -19,7 +19,7 @@ const memory = {}
 const watcher = new XKeysWatcher({
 	automaticUnitIdMode: true,
 
-	// If running on a system (such as some linux flavors) where the 'usb-detection' library doesn't work, enable usePolling instead:
+	// If running on a system (such as some linux flavors) where the 'usb' library doesn't work, enable usePolling instead:
 	// usePolling: true,
 	// pollingInterval: 1000,
 })

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -46,7 +46,7 @@
     "tslib": "^2.4.0"
   },
   "optionalDependencies": {
-    "usb": "^2.5.0"
+    "usb": "^2.5.2"
   },
   "keywords": [
     "xkeys",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -46,7 +46,7 @@
     "tslib": "^2.4.0"
   },
   "optionalDependencies": {
-    "usb-detection": "^4.14.1"
+    "usb": "^2.5.0"
   },
   "keywords": [
     "xkeys",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,6 +13,7 @@
 		"declarationMap": true,
 		// Target: node 10
 		"target": "es2018",
-		"lib": ["es2018"]
+		"lib": ["es2018"],
+		"skipLibCheck": true
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10113,10 +10113,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-usb@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/usb/-/usb-2.5.0.tgz#ee25eb5462131e9e87b9089e33d99aea74fb84c5"
-  integrity sha512-f8Lv1qSM7F2hokhke6zfUw+60winJvi6+yW5MyDt2Zn1Ajv3HCLPhMSzTY/QIKn4cp57N+c5MRuvZGSt0/3dAw==
+usb@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-2.5.2.tgz#081b83aff83279c6d7605608880009ad698bc2c8"
+  integrity sha512-/7hWfbPL4ExGTQO2v2XfuKoBHDwNMoNPZmyKjsPpS4bnEY3BIsaanPpGsLmaI4MOq9pAWDrIz0DwRA8SqJ1pVQ==
   dependencies:
     "@types/w3c-web-usb" "1.0.6"
     node-addon-api "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,6 +1659,11 @@
   resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.3.tgz#e08587a7d737f8654ea6bc0a88689ce5d3ce2d19"
   integrity sha512-eTQRkPd2JukZfS9+kRtrBAaTCCb6waGh5X8BJHmH1MiVQPLMYwm4+EvhwFfOo9SDna15o9dFAwmWwN6r/YM53A==
 
+"@types/w3c-web-usb@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.6.tgz#5d8560d0d9f585ffc80865bc773db7bc975b680c"
+  integrity sha512-cSjhgrr8g4KbPnnijAr/KJDNKa/bBa+ixYkywFRvrhvi9n1WEl7yYbtRyzE6jqNQiSxxJxoAW3STaOQwJHndaw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -3348,13 +3353,6 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
-  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
-  dependencies:
-    mimic-response "^3.1.0"
-
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
@@ -3547,11 +3545,6 @@ detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
-
-detect-libc@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
-  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -4036,11 +4029,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-eventemitter2@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-5.0.1.tgz#6197a095d5fb6b57e8942f6fd7eaad63a09c9452"
-  integrity sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==
 
 eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
@@ -6898,11 +6886,6 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
-  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
 min-indent@^1.0.0, min-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -7102,7 +7085,7 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.15.0:
+nan@^2.12.1:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
@@ -7177,17 +7160,15 @@ node-abi@^2.21.0:
   dependencies:
     semver "^5.4.1"
 
-node-abi@^3.3.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.22.0.tgz#00b8250e86a0816576258227edbce7bbe0039362"
-  integrity sha512-u4uAs/4Zzmp/jjsD9cyFYDXeISfUWaAVWshPmDZOFOv4Xl4SbzTXm53I04C2uRueYJ+0t5PEtLH/owbn2Npf/w==
-  dependencies:
-    semver "^7.3.5"
-
 node-addon-api@^3.0.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-addon-api@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
+  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
 node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
@@ -7200,6 +7181,11 @@ node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
+node-gyp-build@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
+  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
 
 node-gyp@^5.0.2:
   version "5.1.1"
@@ -8052,24 +8038,6 @@ prebuild-install@^6.0.0:
     pump "^3.0.0"
     rc "^1.2.7"
     simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
-prebuild-install@^7.0.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
-  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
-  dependencies:
-    detect-libc "^2.0.0"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^3.3.0"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^4.0.0"
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
@@ -8990,15 +8958,6 @@ simple-get@^3.0.3:
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
-simple-get@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
-  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
-  dependencies:
-    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -10154,15 +10113,14 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-usb-detection@^4.14.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/usb-detection/-/usb-detection-4.14.1.tgz#fe0d4a28299e98b77fe75e416408ebeda38feb0e"
-  integrity sha512-o9JCWXILJDXnlNhjc2abMa/9JTrARVGTjTSYNhgTa1iVJvIwuvmZ5r6hvTeAEZhndC0l1BSFdctMD6QeGwLpOw==
+usb@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-2.5.0.tgz#ee25eb5462131e9e87b9089e33d99aea74fb84c5"
+  integrity sha512-f8Lv1qSM7F2hokhke6zfUw+60winJvi6+yW5MyDt2Zn1Ajv3HCLPhMSzTY/QIKn4cp57N+c5MRuvZGSt0/3dAw==
   dependencies:
-    bindings "^1.5.0"
-    eventemitter2 "^5.0.1"
-    nan "^2.15.0"
-    prebuild-install "^7.0.1"
+    "@types/w3c-web-usb" "1.0.6"
+    node-addon-api "^4.2.0"
+    node-gyp-build "^4.3.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
`usb` now has native usb hotplug detection on all platforms that are supported by `node-hid` https://github.com/node-usb/node-usb/releases/tag/v2.5.0. (Up until now windows was done via polling). It is more actively maintained, and is built with node-api (so no recompile needed when changing node version). Using `usb` should be simpler from a support side as it will break much .less often.

I have given this a quick test on linux, I see no reason it wouldn't behave fine on other platforms