### PR TITLE
feat: use async node-hid

### DIFF
--- a/packages/node-record-test/package.json
+++ b/packages/node-record-test/package.json
@@ -54,7 +54,7 @@
     "@xkeys-lib/core": "3.0.1",
     "readline": "^1.3.0",
     "tslib": "^2.4.0",
-    "xkeys": "3.0.1"
+    "xkeys": "3.1.0-0"
   },
   "optionalDependencies": {
     "find": "^0.3.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys",
-  "version": "2.4.0",
+  "version": "2.5.0-0",
   "description": "An npm module for interfacing with the X-keys panels in Node.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,9 +40,8 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@types/node-hid": "^1.3.1",
     "@xkeys-lib/core": "2.4.0",
-    "node-hid": "^2.1.1",
+    "node-hid": "npm:@julusian/hid@^3.0.0-0",
     "tslib": "^2.4.0"
   },
   "optionalDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,6 +26,10 @@
     {
       "name": "Andreas Reich",
       "url": "https://github.com/cyraxx"
+    },
+    {
+      "name": "Julian Waller",
+      "url": "https://github.com/Julusian"
     }
   ],
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkeys",
-  "version": "2.5.0-0",
+  "version": "2.5.0-1",
   "description": "An npm module for interfacing with the X-keys panels in Node.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/node/src/__mocks__/node-hid.ts
+++ b/packages/node/src/__mocks__/node-hid.ts
@@ -1,62 +1,63 @@
 import { EventEmitter } from 'events'
+import type { Device } from 'node-hid'
+import { XKEYS_VENDOR_ID } from '..'
 
-export interface Device {
-	vendorId: number
-	productId: number
-	path?: string
-	serialNumber?: string
-	manufacturer?: string
-	product?: string
-	release: number
-	interface: number
-	usagePage?: number
-	usage?: number
-}
-
-let mockWriteHandler: undefined | ((hid: HID, message: number[]) => void) = undefined
-export function setMockWriteHandler(handler: (hid: HID, message: number[]) => void) {
+let mockWriteHandler: undefined | ((hid: HIDAsync, message: number[]) => void) = undefined
+export function setMockWriteHandler(handler: (hid: HIDAsync, message: number[]) => void) {
 	mockWriteHandler = handler
 }
 
 // export class HID extends EventEmitter {
-export class HID extends EventEmitter {
+export class HIDAsync extends EventEmitter {
 	private mockWriteHandler
+
+	static async open(path: string): Promise<HIDAsync> {
+		return new HIDAsync(path)
+	}
 
 	constructor(_path: string) {
 		super()
 		this.mockWriteHandler = mockWriteHandler
 	}
 	// constructor(vid: number, pid: number);
-	close(): void {
+	async close(): Promise<void> {
 		// void
 	}
-	pause(): void {
+	async pause(): Promise<void> {
 		// void
 	}
-	read(_callback: (err: any, data: number[]) => void): void {
-		// void
+	async read(_timeOut?: number): Promise<Buffer | undefined> {
+		return undefined
 	}
-	readSync(): number[] {
-		return []
-	}
-	readTimeout(_timeOut: number): number[] {
-		return []
-	}
-	sendFeatureReport(_data: number[]): number {
+	async sendFeatureReport(_data: number[]): Promise<number> {
 		return 0
 	}
-	getFeatureReport(_reportIdd: number, _reportLength: number): number[] {
-		return []
+	async getFeatureReport(_reportIdd: number, _reportLength: number): Promise<Buffer> {
+		return Buffer.alloc(0)
 	}
-	resume(): void {
+	async resume(): Promise<void> {
 		// void
 	}
-	write(message: number[]): number {
+	async write(message: number[]): Promise<number> {
 		this.mockWriteHandler?.(this, message)
 		return 0
 	}
-	setNonBlocking(_noBlock: boolean): void {
+	async setNonBlocking(_noBlock: boolean): Promise<void> {
 		// void
+	}
+
+	async generateDeviceInfo(): Promise<Device> {
+		// HACK: For typings
+		return this.getDeviceInfo()
+	}
+
+	async getDeviceInfo(): Promise<Device> {
+		return {
+			vendorId: XKEYS_VENDOR_ID,
+			productId: 0,
+			release: 0,
+			interface: 0,
+		}
 	}
 }
 export function devices(): Device[] {

--- a/packages/node/src/__tests__/lib.ts
+++ b/packages/node/src/__tests__/lib.ts
@@ -7,7 +7,7 @@ export function getSentData() {
 	return sentData
 }
 
-export function handleXkeysMessages(hid: HID.HID, message: number[]) {
+export function handleXkeysMessages(hid: HID.HIDAsync, message: number[]) {
 	// Replies to a few of the messages that are sent to the XKeys
 
 	sentData.push(Buffer.from(message).toString('hex'))

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -3,7 +3,7 @@ import type * as HID from 'node-hid'
  * This file contains internal convenience functions
  */
 
-export function isHID_Device(device: HID.Device | HID.HID | string): device is HID.Device {
+export function isHID_Device(device: HID.Device | HID.HIDAsync | string): device is HID.Device {
 	return (
 		typeof device === 'object' &&
 		(device as HID.Device).vendorId !== undefined &&
@@ -11,8 +11,8 @@ export function isHID_Device(device: HID.Device | HID.HID | string): device is H
 		(device as HID.Device).interface !== undefined
 	)
 }
-type HID_HID = HID.HID & { devicePath: string }
-export function isHID_HID(device: HID.Device | HID.HID | string): device is HID_HID {
+type HID_HID = HID.HIDAsync & { devicePath: string }
+export function isHID_HID(device: HID.Device | HID.HIDAsync | string): device is HID_HID {
 	return (
 		typeof device === 'object' &&
 		(device as HID_HID).write !== undefined &&

--- a/packages/node/src/lib.ts
+++ b/packages/node/src/lib.ts
@@ -3,20 +3,11 @@ import type * as HID from 'node-hid'
  * This file contains internal convenience functions
  */
 
-export function isHID_Device(device: HID.Device | HID.HIDAsync | string): device is HID.Device {
+export function isHID_Device(device: HID.Device | HID.HID | HID.HIDAsync | string): device is HID.Device {
 	return (
 		typeof device === 'object' &&
 		(device as HID.Device).vendorId !== undefined &&
 		(device as HID.Device).productId !== undefined &&
 		(device as HID.Device).interface !== undefined
-	)
-}
-type HID_HID = HID.HIDAsync & { devicePath: string }
-export function isHID_HID(device: HID.Device | HID.HIDAsync | string): device is HID_HID {
-	return (
-		typeof device === 'object' &&
-		(device as HID_HID).write !== undefined &&
-		(device as HID_HID).getFeatureReport !== undefined &&
-		(device as HID_HID).devicePath !== undefined // yes, HID.HID exposes this, we're using that
 	)
 }

--- a/packages/node/src/methods.ts
+++ b/packages/node/src/methods.ts
@@ -70,7 +70,7 @@ export async function setupXkeysPanel(devicePathOrHIDDevice?: HID.Device | HID.H
 
 		if (!deviceInfo) {
 			// @ts-expect-error getDeviceInfo missing in typings
-			const nodeHidInfo: HID.Device = await this.device.getDeviceInfo()
+			const nodeHidInfo: HID.Device = await device.getDeviceInfo()
 			// Look through HID.devices(), bevause HID.Device contains the productId
 			deviceInfo = {
 				product: nodeHidInfo.product,

--- a/packages/node/src/methods.ts
+++ b/packages/node/src/methods.ts
@@ -57,14 +57,6 @@ export async function setupXkeysPanel(
 				productId: devicePathOrHIDDevice.productId,
 				interface: devicePathOrHIDDevice.interface,
 			}
-		} else if (
-			typeof devicePathOrHIDDevice === 'object' &&
-			typeof (devicePathOrHIDDevice as any).devicePath === 'string'
-		) {
-			// (backwards compatibility): has { devicePath: string }
-
-			devicePath = (devicePathOrHIDDevice as any).devicePath
-			device = await HID.HIDAsync.open(devicePath)
 		} else if (typeof devicePathOrHIDDevice === 'string') {
 			// is string (path)
 

--- a/packages/node/src/methods.ts
+++ b/packages/node/src/methods.ts
@@ -10,11 +10,11 @@ import { HID_Device } from './api'
 /** Sets up a connection to a HID device (the X-keys panel) */
 export function setupXkeysPanel(): Promise<XKeys>
 export function setupXkeysPanel(HIDDevice: HID.Device): Promise<XKeys>
-export function setupXkeysPanel(HIDDevice: HID.HID): Promise<XKeys>
+export function setupXkeysPanel(HIDDevice: HID.HIDAsync): Promise<XKeys>
 export function setupXkeysPanel(devicePath: string): Promise<XKeys>
-export async function setupXkeysPanel(devicePathOrHIDDevice?: HID.Device | HID.HID | string): Promise<XKeys> {
+export async function setupXkeysPanel(devicePathOrHIDDevice?: HID.Device | HID.HIDAsync | string): Promise<XKeys> {
 	let devicePath: string
-	let device: HID.HID
+	let device: HID.HIDAsync | undefined
 	let deviceInfo:
 		| {
 				product: string | undefined
@@ -23,76 +23,79 @@ export async function setupXkeysPanel(devicePathOrHIDDevice?: HID.Device | HID.H
 		  }
 		| undefined
 
-	if (!devicePathOrHIDDevice) {
-		// Device not provided, will then select any connected device:
-		const connectedXkeys = listAllConnectedPanels()
-		if (!connectedXkeys.length) {
-			throw new Error('Could not find any connected X-keys panels.')
+	try {
+		if (!devicePathOrHIDDevice) {
+			// Device not provided, will then select any connected device:
+			const connectedXkeys = listAllConnectedPanels()
+			if (!connectedXkeys.length) {
+				throw new Error('Could not find any connected X-keys panels.')
+			}
+			// Just select the first one:
+			devicePath = connectedXkeys[0].path
+			device = await HID.HIDAsync.open(devicePath)
+
+			deviceInfo = {
+				product: connectedXkeys[0].product,
+				productId: connectedXkeys[0].productId,
+				interface: connectedXkeys[0].interface,
+			}
+		} else if (isHID_Device(devicePathOrHIDDevice)) {
+			// is HID.Device
+
+			if (!devicePathOrHIDDevice.path) throw new Error('HID.Device path not set!')
+
+			devicePath = devicePathOrHIDDevice.path
+			device = await HID.HIDAsync.open(devicePath)
+
+			deviceInfo = {
+				product: devicePathOrHIDDevice.product,
+				productId: devicePathOrHIDDevice.productId,
+				interface: devicePathOrHIDDevice.interface,
+			}
+		} else if (isHID_HID(devicePathOrHIDDevice)) {
+			// is HID.HID
+
+			device = devicePathOrHIDDevice
+			devicePath = devicePathOrHIDDevice.devicePath
+			// deviceInfo is set later
+		} else if (typeof devicePathOrHIDDevice === 'string') {
+			// is string (path)
+
+			devicePath = devicePathOrHIDDevice
+			device = await HID.HIDAsync.open(devicePath)
+			// deviceInfo is set later
+		} else {
+			throw new Error('setupXkeysPanel: invalid arguments')
 		}
-		// Just select the first one:
-		devicePath = connectedXkeys[0].path
-		device = new HID.HID(devicePath)
 
-		deviceInfo = {
-			product: connectedXkeys[0].product,
-			productId: connectedXkeys[0].productId,
-			interface: connectedXkeys[0].interface,
-		}
-	} else if (isHID_Device(devicePathOrHIDDevice)) {
-		// is HID.Device
-
-		if (!devicePathOrHIDDevice.path) throw new Error('HID.Device path not set!')
-
-		devicePath = devicePathOrHIDDevice.path
-		device = new HID.HID(devicePath)
-
-		deviceInfo = {
-			product: devicePathOrHIDDevice.product,
-			productId: devicePathOrHIDDevice.productId,
-			interface: devicePathOrHIDDevice.interface,
-		}
-	} else if (isHID_HID(devicePathOrHIDDevice)) {
-		// is HID.HID
-
-		device = devicePathOrHIDDevice
-		devicePath = devicePathOrHIDDevice.devicePath
-		// deviceInfo is set later
-	} else if (typeof devicePathOrHIDDevice === 'string') {
-		// is string (path)
-
-		devicePath = devicePathOrHIDDevice
-		device = new HID.HID(devicePath)
-		// deviceInfo is set later
-	} else {
-		throw new Error('setupXkeysPanel: invalid arguments')
-	}
-
-	if (!deviceInfo) {
-		// Look through HID.devices(), bevause HID.Device contains the productId
-		for (const hidDevice of HID.devices()) {
-			if (hidDevice.path === devicePath) {
-				deviceInfo = {
-					product: hidDevice.product,
-					productId: hidDevice.productId,
-					interface: hidDevice.interface,
-				}
-				break
+		if (!deviceInfo) {
+			// @ts-expect-error getDeviceInfo missing in typings
+			const nodeHidInfo: HID.Device = await this.device.getDeviceInfo()
+			// Look through HID.devices(), bevause HID.Device contains the productId
+			deviceInfo = {
+				product: nodeHidInfo.product,
+				productId: nodeHidInfo.productId,
+				interface: nodeHidInfo.interface,
 			}
 		}
+
+		if (!device) throw new Error('Error setting up X-keys: device not found')
+		if (!devicePath) throw new Error('Error setting up X-keys: devicePath not found')
+		if (!deviceInfo) throw new Error('Error setting up X-keys: deviceInfo not found')
+
+		const deviceWrap = new NodeHIDDevice(device)
+
+		const xkeys = new XKeys(deviceWrap, deviceInfo, devicePath)
+
+		// Wait for the device to initialize:
+		await xkeys.init()
+
+		return xkeys
+	} catch (e) {
+		if (device) await device.close().catch(() => null) // Suppress error
+
+		throw e
 	}
-
-	if (!device) throw new Error('Error setting up X-keys: device not found')
-	if (!devicePath) throw new Error('Error setting up X-keys: devicePath not found')
-	if (!deviceInfo) throw new Error('Error setting up X-keys: deviceInfo not found')
-
-	const deviceWrap = new NodeHIDDevice(device)
-
-	const xkeys = new XKeys(deviceWrap, deviceInfo, devicePath)
-
-	// Wait for the device to initialize:
-	await xkeys.init()
-
-	return xkeys
 }
 /** Returns a list of all connected X-keys-HID-devices */
 export function listAllConnectedPanels(): HID_Device[] {

--- a/packages/node/src/node-hid-wrapper.ts
+++ b/packages/node/src/node-hid-wrapper.ts
@@ -7,7 +7,7 @@ import * as HID from 'node-hid'
  * This translates it into the common format (@see HIDDevice) defined by @xkeys-lib/core
  */
 export class NodeHIDDevice extends EventEmitter implements HIDDevice {
-	constructor(private device: HID.HID) {
+	constructor(private device: HID.HIDAsync) {
 		super()
 		this._handleData = this._handleData.bind(this)
 		this._handleError = this._handleError.bind(this)
@@ -17,11 +17,13 @@ export class NodeHIDDevice extends EventEmitter implements HIDDevice {
 	}
 
 	public write(data: number[]): void {
-		this.device.write(data)
+		this.device.write(data).catch((err) => {
+			this.emit('error', err)
+		})
 	}
 
 	public async close(): Promise<void> {
-		this.device.close()
+		await this.device.close()
 
 		// For some unknown reason, we need to wait a bit before returning because it
 		// appears that the HID-device isn't actually closed properly until after a short while.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,13 +1754,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-hid@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/node-hid/-/node-hid-1.3.1.tgz#e84507a35a6f3ece3f6324c21ba9252405758b65"
-  integrity sha512-VPxuGDCoDxOUKrTZPSok7IEmiK4cVLfj8Csu09FtG5uF+eqf1HETERHXQkO02Rk6j6YiiHxp0/DA9R4llvhEzQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "18.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
@@ -2601,15 +2594,6 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
-
 body-parser@1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
@@ -2733,7 +2717,7 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
-buffer@^5.2.1, buffer@^5.5.0:
+buffer@^5.2.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -2974,7 +2958,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.1.1, chownr@^1.1.4:
+chownr@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -3567,13 +3551,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
-
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
@@ -3643,11 +3620,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
@@ -3761,11 +3733,6 @@ detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
-
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -3940,7 +3907,7 @@ encoding@^0.1.12:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -4354,11 +4321,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-expand-template@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
-  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 expect@^26.6.2:
   version "26.6.2"
@@ -4995,11 +4957,6 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-github-from-package@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
-  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
-
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -5536,7 +5493,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -7170,11 +7127,6 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 min-indent@^1.0.0, min-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -7201,7 +7153,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -7290,11 +7242,6 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
-
-mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp-infer-owner@^2.0.0:
   version "2.0.0"
@@ -7396,11 +7343,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-napi-build-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
-  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
-
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -7447,14 +7389,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@^2.21.0:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
-  integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
-  dependencies:
-    semver "^5.4.1"
-
-node-addon-api@^3.0.2, node-addon-api@^3.2.1:
+node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -7513,15 +7448,6 @@ node-gyp@^7.1.0:
     semver "^7.3.2"
     tar "^6.0.2"
     which "^2.0.2"
-
-node-hid@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-2.1.1.tgz#f83c8aa0bb4e6758b5f7383542477da93f67359d"
-  integrity sha512-Skzhqow7hyLZU93eIPthM9yjot9lszg9xrKxESleEs05V2NcbUptZc5HFqzjOkSmL0sFlZFr3kmvaYebx06wrw==
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^3.0.2"
-    prebuild-install "^6.0.0"
 
 node-hid@^3.0.0:
   version "3.0.0"
@@ -7746,7 +7672,7 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8365,25 +8291,6 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
 
-prebuild-install@^6.0.0:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
-  integrity sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.21.0"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -8595,16 +8502,6 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -8738,7 +8635,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.0.6:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -9112,7 +9009,7 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -9259,20 +9156,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
-  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
-  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -9788,11 +9671,6 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
-
 strip-outer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
@@ -9865,16 +9743,6 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-fs@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
-  dependencies:
-    chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
-    pump "^3.0.0"
-    tar-stream "^2.1.4"
-
 tar-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
@@ -9887,17 +9755,6 @@ tar-stream@^1.5.2:
     readable-stream "^2.3.0"
     to-buffer "^1.1.1"
     xtend "^4.0.0"
-
-tar-stream@^2.1.4:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
-  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
-  dependencies:
-    bl "^4.0.3"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
 
 tar@^4.4.12:
   version "4.4.19"
@@ -10882,18 +10739,6 @@ ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
-
-xkeys@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/xkeys/-/xkeys-3.0.1.tgz#50be0b196152325121c69df66ed7c27e8df0400a"
-  integrity sha512-fcuDULQrOy4oYryS8nGT+MlnuW161zmO0qr2sB2x4ZdkTuTGP8JeXZ4ltNNxJbOLj55XUZ67yY/idExCBVu4Pw==
-  dependencies:
-    "@types/node-hid" "^1.3.1"
-    "@xkeys-lib/core" "3.0.1"
-    node-hid "^2.1.1"
-    tslib "^2.4.0"
-  optionalDependencies:
-    usb "^2.5.2"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -7160,7 +7169,7 @@ node-abi@^2.21.0:
   dependencies:
     semver "^5.4.1"
 
-node-addon-api@^3.0.2:
+node-addon-api@^3.0.2, node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -7228,6 +7237,14 @@ node-hid@^2.1.1:
     bindings "^1.5.0"
     node-addon-api "^3.0.2"
     prebuild-install "^6.0.0"
+
+"node-hid@npm:@julusian/hid@^3.0.0-0":
+  version "3.0.0-0"
+  resolved "https://registry.yarnpkg.com/@julusian/hid/-/hid-3.0.0-0.tgz#f3cbde6a13781e3c436f388c24225805006582fa"
+  integrity sha512-7k1lpDZcI8zH8Qsu6ivBWMhcJL7TxaJLZiYGx0KoxGPJhOvkEf7z+ZwHk02wZmh+z5gccHGKIpMKhP5P54aZeQ==
+  dependencies:
+    node-addon-api "^3.2.1"
+    pkg-prebuilds "^0.2.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8007,6 +8024,13 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-prebuilds@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/pkg-prebuilds/-/pkg-prebuilds-0.2.1.tgz#4b91f410ab600df4eb657634d623549cc188c5ed"
+  integrity sha512-FdOlDiRqRL7i9aYzQflhGWCoiJf/8u6Qgzq48gKsRDYejtfjvGb1U5QGSzllcqpNg2a8Swx/9fMgtuVefwU+zw==
+  dependencies:
+    yargs "^17.5.1"
 
 portfinder@^1.0.26:
   version "1.0.28"
@@ -9337,7 +9361,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10570,6 +10594,18 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+xkeys@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/xkeys/-/xkeys-2.4.0.tgz#bad32c6968290fa89c66900c53ee4515b4aede54"
+  integrity sha512-/9+U26SlopufMlMvoVEbFCTnSPzl9jKeb3HWjHg5Tl/MQKKQG98yUDWsFF2BGPUKxFwBqZfmYGaQ2jsaD2S5XQ==
+  dependencies:
+    "@types/node-hid" "^1.3.1"
+    "@xkeys-lib/core" "2.4.0"
+    node-hid "^2.1.1"
+    tslib "^2.4.0"
+  optionalDependencies:
+    usb "^2.5.2"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -10636,6 +10672,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -10681,6 +10722,19 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.5.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
This updates the library to node-hid v3.0.0. This switches to using the async version of node-hid, which avoids the limitation of only being able to use  4 devices and increases usb performance by moving the blocking usb ui off of the nodejs main thread.