### PR TITLE
fix: filter for correct usage/usagePage when finding xkeys devices

### DIFF
--- a/packages/webhid/src/methods.ts
+++ b/packages/webhid/src/methods.ts
@@ -63,6 +63,6 @@ export async function setupXkeysPanel(browserDevice: HIDDevice): Promise<XKeys> 
 		return xkeys
 	} catch (e) {
 		await deviceWrap.close()
-		throw new Error('Failed to initialise device')
+		throw e
 	}
 }

--- a/packages/webhid/src/methods.ts
+++ b/packages/webhid/src/methods.ts
@@ -22,7 +22,14 @@ export async function getOpenedXKeysPanels(): Promise<HIDDevice[]> {
 }
 
 function isValidXkeysUsage(device: HIDDevice): boolean {
-	return device.vendorId === XKEYS_VENDOR_ID && !!device.collections.find((collection) => collection.usagePage === 12)
+	if (device.vendorId !== XKEYS_VENDOR_ID) return false
+
+	return !!device.collections.find((collection) => {
+		if (collection.usagePage !== 12) return false
+
+		// Check the write-length of the device is > 20
+		return !!collection.outputReports?.find((report) => !!report.items?.find((item) => item.reportCount ?? 0 > 20))
+	})
 }
 
 /** Sets up a connection to a HID device (the X-keys panel) */

--- a/packages/webhid/src/methods.ts
+++ b/packages/webhid/src/methods.ts
@@ -3,25 +3,32 @@ import { WebHIDDevice } from './web-hid-wrapper'
 
 /** Prompts the user for which X-keys panel to select */
 export async function requestXkeysPanels(): Promise<HIDDevice[]> {
-	return navigator.hid.requestDevice({
+	const allDevices = await navigator.hid.requestDevice({
 		filters: [
 			{
 				vendorId: XKEYS_VENDOR_ID,
 			},
 		],
 	})
+	return allDevices.filter(isValidXkeysUsage)
 }
 /**
  * Reopen previously selected devices.
  * The browser remembers what the user previously allowed your site to access, and this will open those without the request dialog
  */
 export async function getOpenedXKeysPanels(): Promise<HIDDevice[]> {
-	return await navigator.hid.getDevices()
+	const allDevices = await navigator.hid.getDevices()
+	return allDevices.filter(isValidXkeysUsage)
+}
+
+function isValidXkeysUsage(device: HIDDevice): boolean {
+	return device.vendorId === XKEYS_VENDOR_ID && !!device.collections.find((collection) => collection.usagePage === 12)
 }
 
 /** Sets up a connection to a HID device (the X-keys panel) */
 export async function setupXkeysPanel(browserDevice: HIDDevice): Promise<XKeys> {
 	if (!browserDevice?.collections?.length) throw Error(`device collections is empty`)
+	if (!isValidXkeysUsage(browserDevice)) throw new Error(`Device has incorrect usage/interface`)
 	if (!browserDevice.productId) throw Error(`Device has no productId!`)
 
 	const productId = browserDevice.productId
@@ -43,7 +50,12 @@ export async function setupXkeysPanel(browserDevice: HIDDevice): Promise<XKeys> 
 	)
 
 	// Wait for the device to initialize:
-	await xkeys.init()
+	try {
+		await xkeys.init()
 
-	return xkeys
+		return xkeys
+	} catch (e) {
+		await deviceWrap.close()
+		throw new Error('Failed to initialise device')
+	}
 }


### PR DESCRIPTION
fixes #92

The filtering might be overly strict, and needs to be verified on windows and macos to ensure the required properties are defined.

Tested with a XK24 and XK12-Jog