### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -25,7 +25,7 @@ jobs:
           if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
             echo "env NPM_TOKEN not set!"
           else
-            echo ::set-output name=is-ok::"1"
+            echo "is-ok="1"" >> $GITHUB_OUTPUT
           fi
       - name: Prepare Environment
         if: ${{ steps.check-npm-token.outputs.is-ok }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -75,7 +75,7 @@ jobs:
           if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
             echo "env NPM_TOKEN not set!"
           else
-            echo ::set-output name=is-ok::"1"
+            echo "is-ok="1"" >> $GITHUB_OUTPUT
           fi
       - name: Prepare Environment
         if: ${{ steps.check-npm-token.outputs.is-ok }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -108,7 +108,7 @@ jobs:
           if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
             echo "env NPM_TOKEN not set!"
           else
-            echo ::set-output name=is-ok::"1"
+            echo "is-ok="1"" >> $GITHUB_OUTPUT
           fi
       - name: Prepare Environment
         if: ${{ steps.check-npm-token.outputs.is-ok }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


