### PR TITLE
Fix event listener registration (bind this) and removal in web-hid-wrapper.ts

### DIFF
--- a/packages/webhid/src/web-hid-wrapper.ts
+++ b/packages/webhid/src/web-hid-wrapper.ts
@@ -36,13 +36,14 @@ export class WebHIDDevice extends EventEmitter implements CoreHIDDevice {
 
 	public async close(): Promise<void> {
 		await this.device.close()
-		this.device.removeEventListener('inputreport', this._handleInputreport.bind(this))
+		this.device.removeEventListener('inputreport', this._handleInputreport)
+		this.device.removeEventListener('error', this._handleError)
 	}
-	private _handleInputreport(event: HIDInputReportEvent) {
+	private _handleInputreport = (event: HIDInputReportEvent) => {
 		const buf = WebBuffer.from(event.data.buffer)
 		this.emit('data', buf)
 	}
-	private _handleError(error: any) {
+	private _handleError = (error: any) => {
 		this.emit('error', error)
 	}
 }


### PR DESCRIPTION
Not sure how/if this was working previously. Issues fixed:
- registered event listeners should be bound to this
- removed event listeners should be the same function references as were registered
- remove `'error'` event listener on close to avoid memory leak