### PR TITLE
Add implementation of XKeysWatcher for browser environments under web package

### DIFF
--- a/packages/webhid/src/index.ts
+++ b/packages/webhid/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@xkeys-lib/core'
 
-export * from './web-hid-wrapper'
 export * from './methods'
+export * from './watcher'
+export * from './web-hid-wrapper'

--- a/packages/webhid/src/watcher.ts
+++ b/packages/webhid/src/watcher.ts
@@ -3,14 +3,14 @@ import { EventEmitter } from 'events'
 import { XKeys, getOpenedXKeysPanels, setupXkeysPanel } from 'xkeys-webhid'
 
 export type XKeysWatcherEvents = {
-  connected: (xkeysPanel: XKeys) => void
-  error: (err: unknown) => void
+	connected: (xkeysPanel: XKeys) => void
+	error: (err: unknown) => void
 }
 
 export declare interface XKeysWatcher {
-  // Note: This interface defines strong typings for any events that are emitted by the XKeysWatcher class.
-  on<U extends keyof XKeysWatcherEvents>(event: U, listener: XKeysWatcherEvents[U]): this
-  emit<U extends keyof XKeysWatcherEvents>(event: U, ...args: Parameters<XKeysWatcherEvents[U]>): boolean
+	// Note: This interface defines strong typings for any events that are emitted by the XKeysWatcher class.
+	on<U extends keyof XKeysWatcherEvents>(event: U, listener: XKeysWatcherEvents[U]): this
+	emit<U extends keyof XKeysWatcherEvents>(event: U, ...args: Parameters<XKeysWatcherEvents[U]>): boolean
 }
 
 const DEFAULT_POLLING_INTERVAL_MS = 1000
@@ -20,124 +20,123 @@ const DEFAULT_POLLING_INTERVAL_MS = 1000
  * Note: It is highly recommended to set up a listener for the disconnected event on the X-keys panel, to clean up after a disconnected device.
  */
 export class XKeysWatcher extends EventEmitter {
-  private pollingTimeout: number | undefined = undefined
+	private pollingTimeout: number | undefined = undefined
 
-  public debug = false
+	public debug = false
 
-  private readonly seenHidDevices: Set<HIDDevice> = new Set()
-  /** A list of the devices we've called setupXkeysPanels for. */
-  private setupXKeysPanels: XKeys[] = []
-  private readonly hidDeviceToXKeysPanel: WeakMap<HIDDevice, XKeys> = new WeakMap()
-  private readonly hidDeviceToDisconnectedListener: WeakMap<HIDDevice, (...args: unknown[]) => void> = new WeakMap()
+	private readonly seenHidDevices: Set<HIDDevice> = new Set()
+	/** A list of the devices we've called setupXkeysPanels for. */
+	private setupXKeysPanels: XKeys[] = []
+	private readonly hidDeviceToXKeysPanel: WeakMap<HIDDevice, XKeys> = new WeakMap()
+	private readonly hidDeviceToDisconnectedListener: WeakMap<HIDDevice, (...args: unknown[]) => void> = new WeakMap()
 
-  constructor(private readonly options?: XKeysWatcherOptions) {
-    // eslint-disable-next-line constructor-super
-    super()
-    this.triggerUpdateConnectedDevices(true)
-    navigator.hid.on('disconnect', this.handleDisconnect)
-  }
+	constructor(private readonly options?: XKeysWatcherOptions) {
+		// eslint-disable-next-line constructor-super
+		super()
+		this.triggerUpdateConnectedDevices(true)
+		navigator.hid.on('disconnect', this.handleDisconnect)
+	}
 
-  /**
-   * Stop the watcher.
-   *
-   * @param closeAllDevices Set to false in order to NOT close all devices. Use this if you only want to stop the watching. Defaults to true.
-   */
-  public async stop(closeAllDevices = true): Promise<void> {
-    navigator.hid.removeListener('disconnect', this.handleDisconnect)
+	/**
+	 * Stop the watcher.
+	 *
+	 * @param closeAllDevices Set to false in order to NOT close all devices. Use this if you only want to stop the watching. Defaults to true.
+	 */
+	public async stop(closeAllDevices = true): Promise<void> {
+		navigator.hid.removeListener('disconnect', this.handleDisconnect)
 
-    if (this.pollingTimeout !== undefined) {
-      clearTimeout(this.pollingTimeout)
-      this.pollingTimeout = undefined
-    }
+		if (this.pollingTimeout !== undefined) {
+			clearTimeout(this.pollingTimeout)
+			this.pollingTimeout = undefined
+		}
 
-    if (closeAllDevices) {
-      // In order for an application to close gracefully,
-      // we need to close all devices that we've called setupXkeysPanel() on
-      await Promise.all(this.setupXKeysPanels.map((xKeys) => xKeys.close()))
-    }
-  }
+		if (closeAllDevices) {
+			// In order for an application to close gracefully,
+			// we need to close all devices that we've called setupXkeysPanel() on
+			await Promise.all(this.setupXKeysPanels.map((xKeys) => xKeys.close()))
+		}
+	}
 
-  private triggerUpdateConnectedDevices(immediate: boolean) {
-    this.pollingTimeout = (setTimeout as Window['setTimeout'])(
-      async () => {
-        try {
-          await this.updateConnectedDevices()
-        } catch (e) {
-          console.error(e)
-        }
-        this.triggerUpdateConnectedDevices(false)
-      },
-      immediate ? 0 : this.options?.pollingInterval ?? DEFAULT_POLLING_INTERVAL_MS,
-    )
-  }
+	private triggerUpdateConnectedDevices(immediate: boolean) {
+		this.pollingTimeout = (setTimeout as Window['setTimeout'])(
+			async () => {
+				try {
+					await this.updateConnectedDevices()
+				} catch (e) {
+					console.error(e)
+				}
+				this.triggerUpdateConnectedDevices(false)
+			},
+			immediate ? 0 : this.options?.pollingInterval ?? DEFAULT_POLLING_INTERVAL_MS
+		)
+	}
 
-  
-  private async updateConnectedDevices() {
-    const devices = await getOpenedXKeysPanels()
-    
-    // Removed devices:
-    this.seenHidDevices.forEach((device) => {
-      if (!devices.includes(device)) {
-        this.debugLog('removed')
-        this.seenHidDevices.delete(device)
-      }
-    })
-    const unseenDevices = devices.filter((device) => !this.seenHidDevices.has(device))
-    unseenDevices.forEach((device) => this.seenHidDevices.add(device))
-    
-    // Added devices:
-    await Promise.all(
-      unseenDevices.map((device) => {
-        this.debugLog('added')
-        return this.handleNewDevice(device)
-      }),
-    )
-  }
+	private async updateConnectedDevices() {
+		const devices = await getOpenedXKeysPanels()
 
-  private async handleNewDevice(device: HIDDevice) {
-    this.debugLog('handleNewDevice', device.productId)
+		// Removed devices:
+		this.seenHidDevices.forEach((device) => {
+			if (!devices.includes(device)) {
+				this.debugLog('removed')
+				this.seenHidDevices.delete(device)
+			}
+		})
+		const unseenDevices = devices.filter((device) => !this.seenHidDevices.has(device))
+		unseenDevices.forEach((device) => this.seenHidDevices.add(device))
 
-    try {
-      const xKeysPanel = await setupXkeysPanel(device)
-      this.hidDeviceToXKeysPanel.set(device, xKeysPanel)
-      this.setupXKeysPanels.push(xKeysPanel)
+		// Added devices:
+		await Promise.all(
+			unseenDevices.map((device) => {
+				this.debugLog('added')
+				return this.handleNewDevice(device)
+			})
+		)
+	}
 
-      this.emit('connected', xKeysPanel)
+	private async handleNewDevice(device: HIDDevice) {
+		this.debugLog('handleNewDevice', device.productId)
 
-      const handleDisconnected = () => {
-        this.cleanupDevice(device)
-      }
-      this.hidDeviceToDisconnectedListener.set(device, handleDisconnected)
-      xKeysPanel.once('disconnected', handleDisconnected)
-    } catch (e) {
-      this.emit('error', e)
-    }
-  }
-  
-  private handleDisconnect = (device: HIDDevice) => {
-    this.cleanupDevice(device)
-  }
+		try {
+			const xKeysPanel = await setupXkeysPanel(device)
+			this.hidDeviceToXKeysPanel.set(device, xKeysPanel)
+			this.setupXKeysPanels.push(xKeysPanel)
 
-  private cleanupDevice(device: HIDDevice) {
-    const xKeys = this.hidDeviceToXKeysPanel.get(device)
-    const disconnectedListener = this.hidDeviceToDisconnectedListener.get(device)
-    if (xKeys && disconnectedListener) {
-      xKeys.removeListener('disconnected', disconnectedListener)
-    }
-    this.seenHidDevices.delete(device)
-    this.hidDeviceToXKeysPanel.delete(device)
-    this.hidDeviceToDisconnectedListener.delete(device)
-  }
-  
-  private debugLog(...args: any[]) {
-    if (this.debug) console.log(...args)
-  }
+			this.emit('connected', xKeysPanel)
+
+			const handleDisconnected = () => {
+				this.cleanupDevice(device)
+			}
+			this.hidDeviceToDisconnectedListener.set(device, handleDisconnected)
+			xKeysPanel.once('disconnected', handleDisconnected)
+		} catch (e) {
+			this.emit('error', e)
+		}
+	}
+
+	private handleDisconnect = (device: HIDDevice) => {
+		this.cleanupDevice(device)
+	}
+
+	private cleanupDevice(device: HIDDevice) {
+		const xKeys = this.hidDeviceToXKeysPanel.get(device)
+		const disconnectedListener = this.hidDeviceToDisconnectedListener.get(device)
+		if (xKeys && disconnectedListener) {
+			xKeys.removeListener('disconnected', disconnectedListener)
+		}
+		this.seenHidDevices.delete(device)
+		this.hidDeviceToXKeysPanel.delete(device)
+		this.hidDeviceToDisconnectedListener.delete(device)
+	}
+
+	private debugLog(...args: any[]) {
+		if (this.debug) console.log(...args)
+	}
 }
 
 export type XKeysWatcherOptions = {
-  /**
-   * The interval to use for checking for new devices.
-   * Note: This is a lower bound; the real poll rate may be slower if individual polling cycles take longer than the interval.
-   */
-  pollingInterval?: number
+	/**
+	 * The interval to use for checking for new devices.
+	 * Note: This is a lower bound; the real poll rate may be slower if individual polling cycles take longer than the interval.
+	 */
+	pollingInterval?: number
 }

--- a/packages/webhid/src/watcher.ts
+++ b/packages/webhid/src/watcher.ts
@@ -104,11 +104,11 @@ export class XKeysWatcher extends EventEmitter {
 
       this.emit('connected', xKeysPanel)
 
-      const disconnectedListener = () => {
+      const handleDisconnected = () => {
         this.cleanupDevice(device)
       }
-      this.hidDeviceToDisconnectedListener.set(device, disconnectedListener)
-      xKeysPanel.once('disconnected', disconnectedListener)
+      this.hidDeviceToDisconnectedListener.set(device, handleDisconnected)
+      xKeysPanel.once('disconnected', handleDisconnected)
     } catch (e) {
       this.emit('error', e)
     }


### PR DESCRIPTION
#104

Largely based on the existing implementation in https://github.com/SuperFlyTV/xkeys/blob/838adffd0b24b9a749e131855ea5d934f1c6c086/packages/node/src/watcher.ts

Key differences:
- tracks seen devices by the actual `HIDDevice` instance references (stored in a `Set`), as opposed to the `devicePath` (since it is not available for web). Per the spec, these instances should remain stable across calls to the underlying `navigator.hid.getDevices()` (see https://wicg.github.io/webhid/#dom-hid-getdevices "6." > https://wicg.github.io/webhid/#dfn-devices).
- in general, does not call the "hidden" methods `_handleDeviceReconnected`, `_handleDeviceDisconnected`. I was not sure if/why these calls were needed.
- slightly simplified polling logic uses `setTimeout` callbacks calling each other, rather than `setInterval`. This lends itself to a slightly less verbose implementation, and has the added benefit of not flooding the event loop if the polling interval causes a timer rate higher than the system can handle.

Missing features:
- `automaticUnitIdMode`

I tried to keep the code stylistically similar: comments, names, etc. Also included the "dead" debug logging code for convenience.