### PR TITLE
handle error events on xkeys that can be emitted during the init process before the instance is exposed for listener registration

### DIFF
--- a/packages/webhid/src/methods.ts
+++ b/packages/webhid/src/methods.ts
@@ -76,16 +76,18 @@ export async function setupXkeysPanel(browserDevice: HIDDevice): Promise<XKeys> 
 				console.error(`Xkeys: Error emitted after setup already rejected:`, e)
 				return
 			}
-			deviceWrap.close()
+			deviceWrap
+				.close()
 				.then(() => reject())
 				.catch(reject)
 				.finally(() => (alreadyRejected = true))
 		}
-	    // Handle all error events until the instance is returned
+		// Handle all error events until the instance is returned
 		xkeys.on('error', xkeysStopgapErrorHandler)
-		
+
 		// Wait for the device to initialize:
-		xkeys.init()
+		xkeys
+			.init()
 			.then(() => {
 				resolve(xkeys)
 				xkeys.removeListener('error', xkeysStopgapErrorHandler)


### PR DESCRIPTION
Fixes https://github.com/SuperFlyTV/xkeys/issues/112 (implements the first approach discussed)