### PR TITLE
Add `Watcher#getConnectedPanels()` to query connected devices initially or on-demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ watcher.on('connected', (xkeysPanel) => {
 	})
 })
 
+watcher.getConnectedPanels().then((xkeysPanelSet) => {
+  if (xkeysPanelSet.size)
+    console.log(
+      `Found initially connected X-keys panels`,
+      [...xkeysPanelSet].map((xkeysPanel) => xkeysPanel.info.name),
+    );
+});
+
 // To stop watching, call
 // watcher.stop().catch(console.error)
 ```

--- a/packages/core/src/watcher.ts
+++ b/packages/core/src/watcher.ts
@@ -82,6 +82,10 @@ export abstract class GenericXKeysWatcher<HID_Identifier> extends EventEmitter {
 		}
 	}
 
+	public getConnectedPanels(): Promise<Set<XKeys>> {
+		return new Set(await Promise.all((await this.getConnectedDevices()).map((device) => this.setupXkeysPanel(device))))
+	}
+
 	protected triggerUpdateConnectedDevices(somethingWasAddedOrRemoved: boolean): void {
 		if (somethingWasAddedOrRemoved) {
 			this.shouldFindChangedReTries++

--- a/packages/core/src/watcher.ts
+++ b/packages/core/src/watcher.ts
@@ -83,7 +83,7 @@ export abstract class GenericXKeysWatcher<HID_Identifier> extends EventEmitter {
 	}
 
 	public getConnectedPanels(): Promise<Set<XKeys>> {
-		return new Set(await Promise.all((await this.getConnectedDevices()).map((device) => this.setupXkeysPanel(device))))
+		return new Set(await Promise.all([...(await this.getConnectedDevices())].map((device) => this.setupXkeysPanel(device))))
 	}
 
 	protected triggerUpdateConnectedDevices(somethingWasAddedOrRemoved: boolean): void {


### PR DESCRIPTION
#123 